### PR TITLE
Add unique user counter on dashboard

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -7,6 +7,7 @@ class Idea(db.Model):
     title = db.Column(db.String(150), nullable=False)
     description = db.Column(db.Text, nullable=False)
     tags = db.Column(db.String(300))
+    submitter = db.Column(db.String(150))
     is_anonymous = db.Column(db.Boolean, default=False)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
     votes = db.Column(db.Integer, default=0)

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -4,6 +4,7 @@
 
 {% block content %}
   <h2>Submitted Ideas</h2>
+  <p class="idea-count">🚀 {{ unique_user_count }} unique users have submitted ideas so far</p>
 
   {% if ideas %}
     <table>

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,7 +1,17 @@
+import os
+import getpass
 import re
 import xlsxwriter
 import io
 from collections import Counter
+
+# 🔑 Determine the current system username
+def get_current_username() -> str:
+    """Return the current system username in a robust way."""
+    try:
+        return os.getlogin()
+    except OSError:
+        return getpass.getuser()
 
 # 🔖 Generate keyword tags from title + description
 def generate_tags(text, top_n=5):
@@ -20,7 +30,7 @@ def export_ideas_to_excel(ideas):
     workbook = xlsxwriter.Workbook(output, {'in_memory': True})
     sheet = workbook.add_worksheet('Ideas')
 
-    headers = ['ID', 'Title', 'Description', 'Tags', 'Anonymous', 'Timestamp', 'Votes']
+    headers = ['ID', 'Title', 'Description', 'Tags', 'Submitter', 'Anonymous', 'Timestamp', 'Votes']
     for col, header in enumerate(headers):
         sheet.write(0, col, header)
 
@@ -29,9 +39,10 @@ def export_ideas_to_excel(ideas):
         sheet.write(row, 1, idea.title)
         sheet.write(row, 2, idea.description)
         sheet.write(row, 3, idea.tags)
-        sheet.write(row, 4, 'Yes' if idea.is_anonymous else 'No')
-        sheet.write(row, 5, idea.timestamp.strftime('%Y-%m-%d %H:%M'))
-        sheet.write(row, 6, idea.votes)
+        sheet.write(row, 4, idea.submitter or '')
+        sheet.write(row, 5, 'Yes' if idea.is_anonymous else 'No')
+        sheet.write(row, 6, idea.timestamp.strftime('%Y-%m-%d %H:%M'))
+        sheet.write(row, 7, idea.votes)
 
     workbook.close()
     output.seek(0)

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, flash,
 from datetime import datetime
 from app.forms import IdeaForm
 from app.models import db, Idea
-from app.utils import generate_tags, export_ideas_to_excel
+from app.utils import generate_tags, export_ideas_to_excel, get_current_username
 from io import BytesIO
 
 views_bp = Blueprint('views', __name__)
@@ -20,6 +20,7 @@ def submit_idea():
             title=title,
             description=description,
             tags=tags,
+            submitter=get_current_username(),
             is_anonymous=is_anonymous,
             timestamp=datetime.utcnow()
         )
@@ -33,7 +34,8 @@ def submit_idea():
 @views_bp.route('/dashboard')
 def dashboard():
     ideas = Idea.query.order_by(Idea.timestamp.desc()).all()
-    return render_template('dashboard.html', ideas=ideas)
+    unique_user_count = db.session.query(Idea.submitter).filter(Idea.submitter != None).distinct().count()
+    return render_template('dashboard.html', ideas=ideas, unique_user_count=unique_user_count)
 
 @views_bp.route('/idea/<int:idea_id>')
 def idea_detail(idea_id):


### PR DESCRIPTION
## Summary
- record the submitter username for each idea
- expose a helper to get the current system username
- update Excel export with submitter info
- count distinct submitters and display the total on the dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684fb2633f2c833189529073cb7880c1