### PR TITLE
Implement per-user idea voting

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,6 @@
 from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime
+from sqlalchemy import UniqueConstraint
 from . import db
 
 class Idea(db.Model):
@@ -14,3 +15,11 @@ class Idea(db.Model):
 
     def __repr__(self):
         return f'<Idea {self.id} - {self.title}>'
+
+
+class Vote(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    idea_id = db.Column(db.Integer, db.ForeignKey('idea.id'), nullable=False)
+    voter_id = db.Column(db.String(150), nullable=False)
+
+    __table_args__ = (UniqueConstraint('idea_id', 'voter_id', name='unique_vote'),)

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -24,6 +24,7 @@
           <th>Tags</th>
           <th>Submitted</th>
           <th>Votes</th>
+          <th>Vote</th>
           <th>Details</th>
           {% if session.role == 'admin' %}
             <th>Actions</th>
@@ -37,6 +38,16 @@
             <td>{{ idea.tags }}</td>
             <td>{{ idea.timestamp.strftime('%Y-%m-%d %H:%M') }}</td>
             <td>{{ idea.votes }}</td>
+            <td>
+              {% if idea.id in voted_ideas %}
+                You voted
+              {% else %}
+                <form method="POST" action="{{ url_for('views.vote', idea_id=idea.id) }}">
+                  {{ csrf_token() }}
+                  <button type="submit">👍 Vote</button>
+                </form>
+              {% endif %}
+            </td>
             <td><a href="{{ url_for('views.idea_detail', idea_id=idea.id) }}">View</a></td>
 
             {% if session.role == 'admin' %}

--- a/app/templates/idea_detail.html
+++ b/app/templates/idea_detail.html
@@ -13,6 +13,15 @@
   <p><strong>Submitted By:</strong> {{ 'Anonymous' if idea.is_anonymous else 'Identified User' }}</p>
   <p><strong>Votes:</strong> {{ idea.votes }}</p>
 
+  {% if voted %}
+    <p>You already voted for this idea.</p>
+  {% else %}
+    <form method="POST" action="{{ url_for('views.vote', idea_id=idea.id) }}">
+      {{ csrf_token() }}
+      <button type="submit">👍 Vote</button>
+    </form>
+  {% endif %}
+
   <br>
   <a href="{{ url_for('views.dashboard') }}">← Back to Dashboard</a>
 {% endblock %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,6 +4,8 @@ import re
 import xlsxwriter
 import io
 from collections import Counter
+import uuid
+from flask import session
 
 # 🔑 Determine the current system username
 def get_current_username() -> str:
@@ -12,6 +14,18 @@ def get_current_username() -> str:
         return os.getlogin()
     except OSError:
         return getpass.getuser()
+
+# 👤 Determine a stable identifier for voting
+def get_voter_id() -> str:
+    """Return an identifier for the current voter."""
+    if 'username' in session:
+        return session['username']
+
+    device_id = session.get('device_id')
+    if not device_id:
+        device_id = str(uuid.getnode())
+        session['device_id'] = device_id
+    return device_id
 
 # 🔖 Generate keyword tags from title + description
 def generate_tags(text, top_n=5):


### PR DESCRIPTION
## Summary
- add `Vote` model to persist per-user votes
- track voters via `get_voter_id` helper
- record votes with `/vote/<idea_id>` route
- show voting buttons on dashboard and idea pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684fb7f026ec8331934325f9fa16ef5b