### PR TITLE
Add login and landing pages

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -11,3 +11,9 @@ class IdeaForm(FlaskForm):
 
 class VoteForm(FlaskForm):
     submit = SubmitField('\N{THUMBS UP SIGN} Vote')
+
+
+class LoginForm(FlaskForm):
+    """Simple form to capture a username for login/rename."""
+    username = StringField('Username', validators=[DataRequired(), Length(min=1, max=150)])
+    submit = SubmitField('Continue')

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,6 +11,12 @@
     <nav>
       <a href="{{ url_for('views.submit_idea') }}">Submit Idea</a> |
       <a href="{{ url_for('views.dashboard') }}">Dashboard</a>
+      {% if session.username %}
+        | <a href="{{ url_for('views.landing') }}">Landing</a>
+        | <a href="{{ url_for('auth.logout') }}">Logout</a>
+      {% else %}
+        | <a href="{{ url_for('auth.login') }}">Login</a>
+      {% endif %}
     </nav>
     {% if session.username %}
       <p>Welcome {{ session.username }}!</p>

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+
+{% block title %}Welcome{% endblock %}
+
+{% block content %}
+  <h2>Welcome {{ session.username }}!</h2>
+  <p>Update your username below if you'd like to be known by a different name.</p>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.username.label }}<br>
+      {{ form.username(value=session.username, size=40) }}
+      {% if form.username.errors %}
+        <div class="error">{{ form.username.errors[0] }}</div>
+      {% endif %}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn", value='Update') }}
+    </div>
+  </form>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+
+{% block title %}Innovation Hub Login{% endblock %}
+
+{% block content %}
+  <h2>Login</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.username.label }}<br>
+      {{ form.username(size=40) }}
+      {% if form.username.errors %}
+        <div class="error">{{ form.username.errors[0] }}</div>
+      {% endif %}
+    </div>
+    <div class="form-group">
+      {{ form.submit(class="btn") }}
+    </div>
+  </form>
+{% endblock %}

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -1,11 +1,26 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, send_file, session
 from datetime import datetime
-from app.forms import IdeaForm, VoteForm
+from app.forms import IdeaForm, VoteForm, LoginForm
 from app.models import db, Idea, Vote
 from app.utils import generate_tags, export_ideas_to_excel, get_current_username, get_voter_id
+from app.auth import is_admin
 from io import BytesIO
 
 views_bp = Blueprint('views', __name__)
+
+
+@views_bp.route('/landing', methods=['GET', 'POST'])
+def landing():
+    """Landing page shown after login allowing username updates."""
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = form.username.data.strip()
+        session['username'] = user
+        session['role'] = 'admin' if is_admin(user) else 'user'
+        flash('Username updated.', 'success')
+        return redirect(url_for('views.landing'))
+
+    return render_template('landing.html', form=form)
 
 @views_bp.route('/', methods=['GET', 'POST'])
 def submit_idea():

--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -1,16 +1,23 @@
-from flask import Blueprint, session, redirect, url_for
-from app.auth import get_system_user, is_admin
+from flask import Blueprint, session, redirect, url_for, render_template
+from app.auth import is_admin
+from app.forms import LoginForm
 
 auth_bp = Blueprint('auth', __name__)
 
-@auth_bp.route('/login')
+
+@auth_bp.route('/login', methods=['GET', 'POST'])
 def login():
-    user = get_system_user()
-    session['username'] = user
-    session['role'] = 'admin' if is_admin(user) else 'user'
-    return redirect(url_for('views.dashboard'))
+    """Display a simple login form that stores the username in the session."""
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = form.username.data.strip()
+        session['username'] = user
+        session['role'] = 'admin' if is_admin(user) else 'user'
+        return redirect(url_for('views.landing'))
+
+    return render_template('login.html', form=form)
 
 @auth_bp.route('/logout')
 def logout():
     session.clear()
-    return redirect(url_for('views.submit_idea'))
+    return redirect(url_for('auth.login'))


### PR DESCRIPTION
## Summary
- add `LoginForm` for username capture
- create `login.html` template for new login page
- create `landing.html` template with username rename form
- update `base.html` nav with login/logout links
- implement login/logout handlers and landing route

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684fd64f06388331a10be380383c3ac4