### PR TITLE
Allow all users to export ideas

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -63,12 +63,10 @@
       </tbody>
     </table>
 
-    {% if session.role == 'admin' %}
-      <br>
-      <form method="GET" action="{{ url_for('views.export_ideas') }}">
-        <button type="submit">📤 Export All Ideas to Excel</button>
-      </form>
-    {% endif %}
+    <br>
+    <form method="GET" action="{{ url_for('views.export_ideas') }}">
+      <button type="submit">📤 Export All Ideas to Excel</button>
+    </form>
   {% else %}
     <p>No ideas submitted yet.</p>
   {% endif %}


### PR DESCRIPTION
## Summary
- show the export button for all logged in users

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684fe513c41c833195bbdddaf6adbc42