### PR TITLE
Add login requirement and show submitter

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -6,12 +6,14 @@
   <h2>Submitted Ideas</h2>
   <p class="idea-count">🚀 {{ unique_user_count }} unique users have submitted ideas so far</p>
 
-  <h2>Welcome {{ session.username }}</h2>
+  {% if session.username %}
+    <h2>Welcome {{ session.username }}</h2>
 
-  {% if session.role == 'admin' %}
-    <p><strong>Role:</strong> Admin</p>
-  {% else %}
-    <p><strong>Role:</strong> User</p>
+    {% if session.role == 'admin' %}
+      <p><strong>Role:</strong> Admin</p>
+    {% else %}
+      <p><strong>Role:</strong> User</p>
+    {% endif %}
   {% endif %}
 
   {% if ideas %}
@@ -23,6 +25,7 @@
           <th>Title</th>
           <th>Tags</th>
           <th>Submitted</th>
+          <th>Submitted By</th>
           <th>Votes</th>
           <th>Vote</th>
           <th>Details</th>
@@ -37,6 +40,7 @@
             <td>{{ idea.title }}</td>
             <td>{{ idea.tags }}</td>
             <td>{{ idea.timestamp.strftime('%Y-%m-%d %H:%M') }}</td>
+            <td>{{ 'Anonymous' if idea.is_anonymous else idea.submitter }}</td>
             <td>{{ idea.votes }}</td>
             <td>
               {% if idea.id in voted_ideas %}

--- a/app/templates/idea_detail.html
+++ b/app/templates/idea_detail.html
@@ -10,7 +10,7 @@
 
   <p><strong>Tags:</strong> {{ idea.tags }}</p>
   <p><strong>Submitted:</strong> {{ idea.timestamp.strftime('%Y-%m-%d %H:%M') }}</p>
-  <p><strong>Submitted By:</strong> {{ 'Anonymous' if idea.is_anonymous else 'Identified User' }}</p>
+  <p><strong>Submitted By:</strong> {{ 'Anonymous' if idea.is_anonymous else idea.submitter }}</p>
   <p><strong>Votes:</strong> {{ idea.votes }}</p>
 
   {% if voted %}

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -28,6 +28,10 @@ def settings():
 
 @views_bp.route('/', methods=['GET', 'POST'])
 def submit_idea():
+    if 'username' not in session:
+        flash('Please log in to submit an idea.', 'error')
+        return redirect(url_for('auth.login'))
+
     form = IdeaForm()
     if form.validate_on_submit():
         title = form.title.data
@@ -121,6 +125,10 @@ def delete_idea(idea_id):
 
 @views_bp.route('/vote/<int:idea_id>', methods=['POST'])
 def vote(idea_id):
+    if 'username' not in session:
+        flash('Please log in to vote.', 'error')
+        return redirect(url_for('auth.login'))
+
     form = VoteForm()
     if not form.validate_on_submit():
         flash('Invalid vote submission.', 'error')


### PR DESCRIPTION
## Summary
- require login before submitting an idea or voting
- display the submitter's name on the dashboard
- show the submitter on each idea detail page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ff9eb62648331bef54e6fc26018ab