### PR TITLE
Fix patent search URL encoding

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -8,6 +8,7 @@ import uuid
 from flask import session
 from app.models import Idea
 from sqlalchemy import or_
+from urllib.parse import quote_plus
 
 # 🔑 Determine the current system username
 def get_current_username() -> str:
@@ -60,7 +61,7 @@ def find_similar_ideas(new_idea_tags, exclude_id=None, max_results=5):
 # 🌐 Generate Google Patents search URL
 def generate_patent_search_url(title, tags):
     query_terms = title + " " + " ".join(tags)
-    query_string = re.sub(r'\s+', '+', query_terms.strip())
+    query_string = quote_plus(query_terms.strip())
     return f"https://patents.google.com/?q={query_string}"
 
 # 📦 Export list of ideas to Excel


### PR DESCRIPTION
## Summary
- use `urllib.parse.quote_plus` to encode search terms for the patent URL

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68501a0051cc833190f269371093740c