### PR TITLE
Ignore __pycache__ directories globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+**/__pycache__/
 *.py[cod]
 *.pyo
 


### PR DESCRIPTION
## Summary
- ensure `__pycache__` folders don't get tracked by adding a recursive ignore rule
- cleaned up any stray `__pycache__` directories

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68501a048edc8331a6b13dfd09b6f19f