### PR TITLE
Allow authors to manage their own ideas

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -46,7 +46,7 @@
           {% endif %}
           <p><a href="{{ url_for('views.idea_detail', idea_id=idea.id) }}">🔍 View Details</a></p>
 
-          {% if session.role == 'admin' %}
+          {% if session.role == 'admin' or session.username == idea.submitter %}
             <div class="admin-actions">
               <a href="{{ url_for('views.edit_idea', idea_id=idea.id) }}">✏️ Edit</a> |
               <a href="{{ url_for('views.delete_idea', idea_id=idea.id) }}" onclick="return confirm('Are you sure?');">🗑️ Delete</a>

--- a/app/templates/idea_detail.html
+++ b/app/templates/idea_detail.html
@@ -41,5 +41,12 @@
     </ul>
   </div>
 {% endif %}
+{% if session.username == idea.submitter %}
+  <div class="section">
+    <h3>📄 Related Patents</h3>
+    <p>Explore similar patents that align with your idea.</p>
+    <a href="{{ patent_url }}" target="_blank" rel="noopener" class="btn btn-secondary">🔗 View on Google Patents</a>
+  </div>
+{% endif %}
   <a href="{{ url_for('views.dashboard') }}">← Back to Dashboard</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- permit idea owners to edit or delete their submissions
- show edit/delete actions on dashboard to the author
- show patent search link on the idea detail page for the submitter

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850e1687d448331ba52122cfade2e9a