### PR TITLE
Add about popup with Teams link

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -537,3 +537,39 @@ a.btn:hover,
 .flash.success { background-color: #e6ffed; border-color: #2ecc71; }
 .flash.error { background-color: #ffe6e6; border-color: #e74c3c; }
 .flash.warning { background-color: #fff8e1; border-color: #f1c40f; }
+
+/* About section */
+.about-link {
+  opacity: 0.4;
+  margin-top: 5px;
+}
+
+.about-link a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.about-link a:hover {
+  opacity: 1;
+}
+
+.about-popup {
+  display: none;
+  position: fixed;
+  bottom: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 8px 12px;
+  border-radius: 6px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.15);
+  font-size: 0.9em;
+  z-index: 1000;
+  text-align: center;
+}
+
+.about-link:hover + .about-popup,
+.about-popup:hover {
+  display: block;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -42,6 +42,13 @@
 
   <footer class="footer">
     <p>💡 Made for team collaboration and innovation at Caterpillar Inc.</p>
+    <p class="about-link"><a href="#" id="about-link">About</a></p>
+    <div id="about-popup" class="about-popup">
+      <p>
+        Innovation Hub for crowdsourcing ideas. Created by
+        <a href="{{ generate_teams_link('sivasudhan', 'Hi! i found your webpage interesting would like to discuss more on that!') }}" target="_blank">Siva Sudhan</a>.
+      </p>
+    </div>
   </footer>
 </body>
 </html>

--- a/app/utils.py
+++ b/app/utils.py
@@ -114,7 +114,12 @@ def export_ideas_to_excel(ideas):
     output.seek(0)
     return output
 
-def generate_teams_link(username: str) -> str:
+def generate_teams_link(username: str, message: str | None = None) -> str:
+    """Return a Microsoft Teams chat link with an optional custom message."""
     base = "https://teams.microsoft.com/l/chat/0/0"
-    message = f"Hi! I found your idea on the Innovation Hub and would love to collaborate."
-    return f"{base}?users={username}@caterpillar.com&message={message}"
+    if message is None:
+        message = (
+            "Hi! I found your idea on the Innovation Hub and would love to collaborate."
+        )
+    encoded = quote_plus(message)
+    return f"{base}?users={username}@caterpillar.com&message={encoded}"


### PR DESCRIPTION
## Summary
- include about link and popup in footer
- create `generate_teams_link` helper with optional message param
- style about link with CSS and show popup on hover

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850ef1179ac83318998e01124008b1b