### PR TITLE
Fix duplicate import in utils

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,5 @@
 import os
 import getpass
-import re
 import xlsxwriter
 import io
 from collections import Counter


### PR DESCRIPTION
## Summary
- remove redundant `import re` line from `app/utils.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f14a01988331937f02effe847cff