### PR TITLE
Enable rich text editing for ideas

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -553,6 +553,10 @@ a.btn:hover,
   opacity: 1;
 }
 
+.idea-description {
+  margin-bottom: 1em;
+}
+
 .about-popup {
   display: none;
   position: fixed;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
   <title>{% block title %}Innovation Hub{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {% block head_extra %}{% endblock %}
 </head>
 <body>
   <header class="header-bar">
@@ -50,5 +51,6 @@
       </p>
     </div>
   </footer>
+  {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/app/templates/edit_idea.html
+++ b/app/templates/edit_idea.html
@@ -2,6 +2,10 @@
 
 {% block title %}Edit Idea – Innovation Hub{% endblock %}
 
+{% block head_extra %}
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+{% endblock %}
+
 {% block content %}
   <h2 class="page-heading">🛠️ Edit Idea</h2>
 
@@ -19,7 +23,8 @@
 
       <div class="form-group">
         <label>{{ form.description.label }}</label><br>
-        {{ form.description(rows=6, cols=60, class="input-textarea") }}
+        <div id="quill-editor" style="height: 200px;"></div>
+        {{ form.description(rows=6, cols=60, class="input-textarea", style="display:none;") }}
         {% if form.description.errors %}
           <div class="error">{{ form.description.errors[0] }}</div>
         {% endif %}
@@ -55,4 +60,29 @@
   <div class="back-link">
     <a href="{{ url_for('views.dashboard') }}">← Back to Dashboard</a>
   </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
+  <script>
+    var quill = new Quill('#quill-editor', {
+      theme: 'snow',
+      modules: {
+        toolbar: [
+          ['bold', 'italic', 'underline'],
+          [{ list: 'bullet' }],
+          [{ align: [] }],
+          ['clean']
+        ]
+      }
+    });
+
+    // Populate editor with existing description
+    quill.root.innerHTML = document.querySelector('textarea[name="description"]').value;
+
+    document.querySelector('.idea-form').addEventListener('submit', function () {
+      var descField = document.querySelector('textarea[name="description"]');
+      descField.value = quill.root.innerHTML;
+    });
+  </script>
 {% endblock %}

--- a/app/templates/idea_detail.html
+++ b/app/templates/idea_detail.html
@@ -6,7 +6,7 @@
   <h2>{{ idea.title }}</h2>
 
   <p><strong>Description:</strong></p>
-  <p>{{ idea.description }}</p>
+  <div class="idea-description">{{ idea.description|safe }}</div>
 
   <p><strong>Tags:</strong> {{ idea.tags }}</p>
   <p><strong>Submitted:</strong> {{ idea.timestamp.strftime('%Y-%m-%d %H:%M') }}</p>

--- a/app/templates/submit.html
+++ b/app/templates/submit.html
@@ -2,6 +2,10 @@
 
 {% block title %}Submit Idea{% endblock %}
 
+{% block head_extra %}
+  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+{% endblock %}
+
 {% block content %}
   <div class="idea-form-wrapper animate-fade-in">
     <h2 class="form-title">📝 Submit a New Idea</h2>
@@ -19,7 +23,8 @@
 
       <div class="form-group">
         {{ form.description.label }}<br>
-        {{ form.description(class="textarea", placeholder="Describe the idea, problem it solves, or its potential impact...") }}
+        <div id="quill-editor" style="height: 200px;"></div>
+        {{ form.description(class="textarea", style="display:none;") }}
         {% if form.description.errors %}
           <div class="error">{{ form.description.errors[0] }}</div>
         {% endif %}
@@ -69,7 +74,26 @@
       </div>
     </div>
   </div>
+{% block scripts %}
+  <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
   <script>
+    var quill = new Quill('#quill-editor', {
+      theme: 'snow',
+      modules: {
+        toolbar: [
+          ['bold', 'italic', 'underline'],
+          [{ list: 'bullet' }],
+          [{ align: [] }],
+          ['clean']
+        ]
+      }
+    });
+
+    document.querySelector('.idea-form').addEventListener('submit', function () {
+      var descField = document.querySelector('textarea[name="description"]');
+      descField.value = quill.root.innerHTML;
+    });
+
     async function fetchStats() {
       try {
         const res = await fetch('/api/stats');


### PR DESCRIPTION
## Summary
- add optional blocks in base layout for page-specific assets
- enable Quill rich text editor on idea submit and edit pages
- render idea descriptions as HTML on detail page
- add basic styling for displayed descriptions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851955eb06083318c4edee7a9d3e11e