### PR TITLE
Add click-based About popup

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -567,9 +567,11 @@ a.btn:hover,
   font-size: 0.9em;
   z-index: 1000;
   text-align: center;
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
-.about-link:hover + .about-popup,
-.about-popup:hover {
+.about-popup.active {
   display: block;
+  opacity: 1;
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -42,7 +42,7 @@
 
   <footer class="footer">
     <p>💡 Made for team collaboration and innovation at Caterpillar Inc.</p>
-    <p class="about-link"><a href="#" id="about-link">About</a></p>
+    <p class="about-link"><a href="#" id="about-link">Click to see details</a></p>
     <div id="about-popup" class="about-popup">
       <p>
         Innovation Hub for crowdsourcing ideas. Created by
@@ -50,5 +50,31 @@
       </p>
     </div>
   </footer>
+  <script>
+    const aboutLink = document.getElementById('about-link');
+    const aboutPopup = document.getElementById('about-popup');
+    let hideTimeout;
+
+    function showPopup() {
+      clearTimeout(hideTimeout);
+      aboutPopup.classList.add('active');
+      hideTimeout = setTimeout(hidePopup, 5000);
+    }
+
+    function hidePopup() {
+      aboutPopup.classList.remove('active');
+    }
+
+    aboutLink.addEventListener('click', function(e) {
+      e.preventDefault();
+      showPopup();
+    });
+
+    document.addEventListener('click', function(e) {
+      if (!aboutPopup.contains(e.target) && e.target !== aboutLink) {
+        hidePopup();
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- switch About popup to trigger on click instead of hover
- update About popup style for fade out behaviour
- automatically hide About popup after 5 seconds or when clicking outside
- adjust About footer text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685222bbf9d483319e3794337beef3dd