### PR TITLE
Add dynamic logo support

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -28,8 +28,11 @@ def create_app():
     app.register_blueprint(gamification_bp)
 
     # Jinja global functions
-    from app.utils import generate_teams_link
-    app.jinja_env.globals.update(generate_teams_link=generate_teams_link)
+    from app.utils import generate_teams_link, get_logo_path
+    app.jinja_env.globals.update(
+        generate_teams_link=generate_teams_link,
+        get_logo_path=get_logo_path,
+    )
 
     # Create DB tables
     with app.app_context():

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -144,6 +144,12 @@ body {
   margin: 0;
 }
 
+.site-title img {
+  height: 24px;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+
 .nav-links a {
   color: #FFCD00;
   text-decoration: none;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,7 +9,15 @@
 <body>
   <header class="header-bar">
     <div class="header-content">
-      <h1 class="site-title">🚀 Innovation Hub</h1>
+      <h1 class="site-title">
+        {% set logo = get_logo_path() %}
+        {% if logo %}
+          <img src="{{ url_for('static', filename=logo) }}" alt="logo">
+        {% else %}
+          🚀
+        {% endif %}
+        Innovation Hub
+      </h1>
       <nav class="nav-links">
         <a href="{{ url_for('views.submit_idea') }}">Submit Idea</a>
         <a href="{{ url_for('views.dashboard') }}">Dashboard</a>

--- a/app/utils.py
+++ b/app/utils.py
@@ -10,6 +10,17 @@ from typing import Optional, List
 import re
 from sklearn.feature_extraction.text import TfidfVectorizer
 
+def get_logo_path() -> Optional[str]:
+    """Return the relative path of the first logo image in ``static/images``."""
+    images_dir = os.path.join(os.path.dirname(__file__), 'static', 'images')
+    if not os.path.isdir(images_dir):
+        return None
+
+    for name in sorted(os.listdir(images_dir)):
+        if name.lower().endswith(('.png', '.jpg', '.jpeg', '.gif')):
+            return f'images/{name}'
+    return None
+
 # Manually defined lightweight stopwords list
 STATIC_STOPWORDS = set([
     'the', 'and', 'is', 'in', 'to', 'of', 'for', 'a', 'an', 'with', 'on', 'this',


### PR DESCRIPTION
## Summary
- detect logo image automatically from static directory
- expose helper in Flask app
- show logo next to Innovation Hub title
- style header logo

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685233b0ae0c83318144f6b70cdcb527