### PR TITLE
Add keyword filter to dashboard

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -638,3 +638,24 @@ a.btn:hover,
   font-size: 0.9em;
   vertical-align: middle;
 }
+
+/* Controls row above idea cards */
+.controls-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.controls-row input[type="text"] {
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  max-width: 250px;
+}
+
+/* Highlight text when filtering */
+.keyword-highlight {
+  background-color: #FFCD00;
+  color: #000;
+}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -15,12 +15,15 @@
     {% endif %}
   </div>
 
-  <div class="toggle-container">
-    <label class="switch">
-      <input type="checkbox" id="mineToggle" onclick="toggleFilter(this)" {{ 'checked' if filter_my else '' }}>
-      <span class="slider"></span>
-    </label>
-    <span class="toggle-label">{{ 'My Submissions' if filter_my else 'All Submissions' }}</span>
+  <div class="controls-row">
+    <input type="text" id="keywordSearch" placeholder="Filter by keyword">
+    <div class="toggle-container">
+      <label class="switch">
+        <input type="checkbox" id="mineToggle" onclick="toggleFilter(this)" {{ 'checked' if filter_my else '' }}>
+        <span class="slider"></span>
+      </label>
+      <span class="toggle-label">{{ 'My Submissions' if filter_my else 'All Submissions' }}</span>
+    </div>
   </div>
 
   {% if ideas %}
@@ -115,5 +118,46 @@
   
     fetchLeaderboard();
     setInterval(fetchLeaderboard, 5000);
+
+    const searchInput = document.getElementById('keywordSearch');
+    if (searchInput) {
+      searchInput.addEventListener('input', () => filterCards(searchInput.value));
+    }
+
+    function filterCards(query) {
+      const cards = document.querySelectorAll('.idea-card');
+      cards.forEach(card => {
+        removeHighlights(card);
+        if (!query) {
+          card.style.display = '';
+        } else if (card.innerText.toLowerCase().includes(query.toLowerCase())) {
+          card.style.display = '';
+          highlightMatches(card, query);
+        } else {
+          card.style.display = 'none';
+        }
+      });
+    }
+
+    function highlightMatches(card, text) {
+      const regex = new RegExp('(' + escapeReg(text) + ')', 'gi');
+      const titleEl = card.querySelector('h3');
+      if (titleEl) {
+        titleEl.innerHTML = titleEl.textContent.replace(regex, '<span class="keyword-highlight">$1</span>');
+      }
+      card.querySelectorAll('.tag').forEach(tagEl => {
+        tagEl.innerHTML = tagEl.textContent.replace(regex, '<span class="keyword-highlight">$1</span>');
+      });
+    }
+
+    function removeHighlights(card) {
+      card.querySelectorAll('.keyword-highlight').forEach(span => {
+        span.replaceWith(span.textContent);
+      });
+    }
+
+    function escapeReg(str) {
+      return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add search input above idea cards
- highlight matching keywords and filter cards on dashboard
- style controls row and highlight class

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68528c79637883318417082bd37043ef