### PR TITLE
Fix idea description formatting

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -659,3 +659,7 @@ a.btn:hover,
   background-color: #FFCD00;
   color: #000;
 }
+
+.idea-description {
+  white-space: pre-line;
+}

--- a/app/templates/idea_detail.html
+++ b/app/templates/idea_detail.html
@@ -6,7 +6,7 @@
   <h2>{{ idea.title }}</h2>
 
   <p><strong>Description:</strong></p>
-  <p>{{ idea.description }}</p>
+  <p class="idea-description">{{ idea.description }}</p>
 
   <p><strong>Tags:</strong> {{ idea.tags }}</p>
   <p><strong>Submitted:</strong> {{ idea.timestamp.strftime('%Y-%m-%d %H:%M') }}</p>


### PR DESCRIPTION
## Summary
- preserve multi-line formatting when showing idea descriptions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852ce84dcc0833184a2ad9d662f9939