### PR TITLE
Add events calendar page

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,5 +1,12 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, TextAreaField, BooleanField, SubmitField, SelectField
+from wtforms import (
+    StringField,
+    TextAreaField,
+    BooleanField,
+    SubmitField,
+    SelectField,
+    DateField,
+)
 from wtforms.validators import DataRequired, Length, Optional
 
 class IdeaForm(FlaskForm):
@@ -22,3 +29,11 @@ class VoteForm(FlaskForm):
 class LoginForm(FlaskForm):
     username = StringField('Username', validators=[DataRequired(), Length(min=1, max=150)])
     submit = SubmitField('Continue')
+
+
+class EventForm(FlaskForm):
+    title = StringField('Event Title', validators=[DataRequired(), Length(max=150)])
+    start_date = DateField('Start Date', validators=[DataRequired()], format='%Y-%m-%d')
+    end_date = DateField('End Date', validators=[DataRequired()], format='%Y-%m-%d')
+    color = StringField('Color Hex', validators=[Optional(), Length(max=20)], default='#FFCD00')
+    submit = SubmitField('Add Event')

--- a/app/models.py
+++ b/app/models.py
@@ -24,3 +24,14 @@ class Vote(db.Model):
     voter_id = db.Column(db.String(150), nullable=False)
 
     __table_args__ = (UniqueConstraint('idea_id', 'voter_id', name='unique_vote'),)
+
+
+class Event(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(150), nullable=False)
+    start_date = db.Column(db.Date, nullable=False)
+    end_date = db.Column(db.Date, nullable=False)
+    color = db.Column(db.String(20), default="#FFCD00")
+
+    def __repr__(self):
+        return f"<Event {self.title} {self.start_date} - {self.end_date}>"

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -663,3 +663,26 @@ a.btn:hover,
 .idea-description {
   white-space: pre-line;
 }
+
+/* Calendar */
+.calendar {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+.calendar th, .calendar td {
+  border: 1px solid #ddd;
+  width: 14.2%;
+  height: 80px;
+  vertical-align: top;
+  position: relative;
+}
+.calendar-controls {
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  margin-bottom: 10px;
+}
+.day-number {
+  font-weight: bold;
+}

--- a/app/templates/admin/admin_dashboard.html
+++ b/app/templates/admin/admin_dashboard.html
@@ -42,6 +42,7 @@
     <div class="admin-actions">
         <a href="{{ url_for('admin.export_all_data') }}" class="btn btn-secondary">📤 Export Raw DB</a>
         <a href="{{ url_for('admin.import_raw_data') }}" class="btn btn-secondary">📥 Import Raw DB</a>
+        <a href="{{ url_for('admin.new_event') }}" class="btn btn-secondary">📅 Add Event</a>
     </div>
   </div>
 

--- a/app/templates/admin/new_event.html
+++ b/app/templates/admin/new_event.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+
+{% block title %}Add Event{% endblock %}
+
+{% block content %}
+  <h2>Add Event</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.title.label }}<br>
+      {{ form.title(class="input") }}
+    </div>
+    <div class="form-group">
+      {{ form.start_date.label }}<br>
+      {{ form.start_date(class="input", type="date") }}
+    </div>
+    <div class="form-group">
+      {{ form.end_date.label }}<br>
+      {{ form.end_date(class="input", type="date") }}
+    </div>
+    <div class="form-group">
+      {{ form.color.label }}<br>
+      {{ form.color(class="input", type="color") }}
+    </div>
+    {{ form.submit(class="btn-primary") }}
+  </form>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -21,6 +21,7 @@
       <nav class="nav-links">
         <a href="{{ url_for('views.submit_idea') }}">Submit Idea</a>
         <a href="{{ url_for('views.dashboard') }}">Dashboard</a>
+        <a href="{{ url_for('views.events') }}">Events</a>
         {% if session.username %}
           {% if session.role == 'admin' %}
             <a href="{{ url_for('admin.admin_dashboard') }}">Admin Panel</a>

--- a/app/templates/calendar.html
+++ b/app/templates/calendar.html
@@ -1,0 +1,100 @@
+{% extends 'base.html' %}
+
+{% block title %}Events Calendar{% endblock %}
+
+{% block content %}
+  <h2 class="page-heading">Events Calendar</h2>
+  <div class="calendar-controls">
+    <label>Month
+      <input type="range" id="monthSlider" min="1" max="12" value="{{ month }}">
+    </label>
+    <label>Year
+      <input type="range" id="yearSlider" min="2020" max="2100" value="{{ year }}">
+    </label>
+  </div>
+  <table class="calendar" id="calendarTable">
+    <thead>
+      <tr>
+        <th>Sun</th>
+        <th>Mon</th>
+        <th>Tue</th>
+        <th>Wed</th>
+        <th>Thu</th>
+        <th>Fri</th>
+        <th>Sat</th>
+      </tr>
+    </thead>
+    <tbody id="calendarBody">
+    </tbody>
+  </table>
+  <script>
+    const events = {{ events|tojson }};
+    const month = {{ month }};
+    const year = {{ year }};
+
+    const monthSlider = document.getElementById('monthSlider');
+    const yearSlider = document.getElementById('yearSlider');
+
+    function getEventsMap() {
+      const map = {};
+      events.forEach(ev => {
+        const start = new Date(ev.start_date);
+        const end = new Date(ev.end_date);
+        for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+          const key = d.toISOString().slice(0,10);
+          if (!map[key]) map[key] = [];
+          map[key].push(ev);
+        }
+      });
+      return map;
+    }
+
+    function renderCalendar(m, y) {
+      const firstDay = new Date(y, m-1, 1);
+      const lastDay = new Date(y, m, 0).getDate();
+      const startDay = firstDay.getDay();
+      const body = document.getElementById('calendarBody');
+      const eventsMap = getEventsMap();
+      body.innerHTML = '';
+      let row = document.createElement('tr');
+      for (let i=0;i<startDay;i++) {
+        row.appendChild(document.createElement('td'));
+      }
+      for (let date=1; date<=lastDay; date++) {
+        if (row.children.length === 7) {
+          body.appendChild(row);
+          row = document.createElement('tr');
+        }
+        const cell = document.createElement('td');
+        const cellDate = new Date(y, m-1, date);
+        const key = cellDate.toISOString().slice(0,10);
+        cell.innerHTML = `<div class="day-number">${date}</div>`;
+        if (eventsMap[key]) {
+          const ev = eventsMap[key][0];
+          cell.style.backgroundColor = ev.color;
+          cell.title = eventsMap[key].map(e=>e.title).join('\n');
+        }
+        row.appendChild(cell);
+      }
+      if (row.children.length) {
+        while (row.children.length < 7) row.appendChild(document.createElement('td'));
+        body.appendChild(row);
+      }
+    }
+
+    monthSlider.addEventListener('change', () => {
+      const params = new URLSearchParams(window.location.search);
+      params.set('month', monthSlider.value);
+      params.set('year', yearSlider.value);
+      window.location.search = params.toString();
+    });
+    yearSlider.addEventListener('change', () => {
+      const params = new URLSearchParams(window.location.search);
+      params.set('month', monthSlider.value);
+      params.set('year', yearSlider.value);
+      window.location.search = params.toString();
+    });
+
+    renderCalendar(month, year);
+  </script>
+{% endblock %}

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -1,8 +1,8 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, send_file, session
 from sqlalchemy.exc import IntegrityError
 from datetime import datetime
-from app.forms import IdeaForm, VoteForm, LoginForm
-from app.models import db, Idea, Vote
+from app.forms import IdeaForm, VoteForm, LoginForm, EventForm
+from app.models import db, Idea, Vote, Event
 from app.utils import (
     generate_tags,
     export_ideas_to_excel,
@@ -184,3 +184,26 @@ def export_ideas():
     ideas = Idea.query.order_by(Idea.timestamp.desc()).all()
     output = export_ideas_to_excel(ideas)
     return send_file(output, as_attachment=True, download_name='ideas.xlsx')
+
+
+@views_bp.route('/events')
+def events():
+    from calendar import monthrange
+    month = request.args.get('month', type=int) or datetime.utcnow().month
+    year = request.args.get('year', type=int) or datetime.utcnow().year
+
+    start_month = datetime(year, month, 1).date()
+    end_month = datetime(year, month, monthrange(year, month)[1]).date()
+
+    events = (
+        Event.query
+        .filter(Event.start_date <= end_month, Event.end_date >= start_month)
+        .all()
+    )
+
+    return render_template(
+        'calendar.html',
+        month=month,
+        year=year,
+        events=events,
+    )

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -1,8 +1,9 @@
 # File: app/views/admin.py
 
 from flask import Blueprint, render_template, session, redirect, url_for, flash, request, send_file
-from app.models import db, Idea
+from app.models import db, Idea, Event
 from app.auth import is_admin
+from app.forms import EventForm
 import os, json
 from datetime import datetime
 from collections import defaultdict
@@ -118,6 +119,23 @@ def export_all_data():
     output.seek(0)
 
     return send_file(output, as_attachment=True, download_name='raw_idea_data.json')
+
+
+@admin_bp.route('/events/new', methods=['GET', 'POST'])
+def new_event():
+    form = EventForm()
+    if form.validate_on_submit():
+        event = Event(
+            title=form.title.data,
+            start_date=form.start_date.data,
+            end_date=form.end_date.data,
+            color=form.color.data or '#FFCD00',
+        )
+        db.session.add(event)
+        db.session.commit()
+        flash('Event added.', 'success')
+        return redirect(url_for('admin.new_event'))
+    return render_template('admin/new_event.html', form=form)
 
 @admin_bp.route('/import', methods=['GET', 'POST'])
 def import_raw_data():


### PR DESCRIPTION
## Summary
- allow admin to add events with date ranges and colours
- create events calendar page with month/year sliders
- link to events calendar in navigation and admin dashboard
- style calendar elements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853d3e86af08331ac0503ad93319e7f