### PR TITLE
Fix events view serialization and admin UI

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -35,5 +35,4 @@ class EventForm(FlaskForm):
     title = StringField('Event Title', validators=[DataRequired(), Length(max=150)])
     start_date = DateField('Start Date', validators=[DataRequired()], format='%Y-%m-%d')
     end_date = DateField('End Date', validators=[DataRequired()], format='%Y-%m-%d')
-    color = StringField('Color Hex', validators=[Optional(), Length(max=20)], default='#FFCD00')
     submit = SubmitField('Add Event')

--- a/app/templates/admin/new_event.html
+++ b/app/templates/admin/new_event.html
@@ -18,10 +18,20 @@
       {{ form.end_date.label }}<br>
       {{ form.end_date(class="input", type="date") }}
     </div>
-    <div class="form-group">
-      {{ form.color.label }}<br>
-      {{ form.color(class="input", type="color") }}
-    </div>
     {{ form.submit(class="btn-primary") }}
   </form>
+
+  <h3>Existing Events</h3>
+  <ul>
+    {% for ev in events %}
+      <li>
+        <span style="background-color: {{ ev.color }}; padding: 2px 6px;">
+          {{ ev.title }} ({{ ev.start_date }} - {{ ev.end_date }})
+        </span>
+        <a href="{{ url_for('admin.delete_event', event_id=ev.id) }}" onclick="return confirm('Delete this event?');">Delete</a>
+      </li>
+    {% else %}
+      <li>No events yet.</li>
+    {% endfor %}
+  </ul>
 {% endblock %}

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -195,11 +195,21 @@ def events():
     start_month = datetime(year, month, 1).date()
     end_month = datetime(year, month, monthrange(year, month)[1]).date()
 
-    events = (
+    events_query = (
         Event.query
         .filter(Event.start_date <= end_month, Event.end_date >= start_month)
         .all()
     )
+    events = [
+        {
+            'id': ev.id,
+            'title': ev.title,
+            'start_date': ev.start_date.isoformat(),
+            'end_date': ev.end_date.isoformat(),
+            'color': ev.color,
+        }
+        for ev in events_query
+    ]
 
     month_name = datetime(year, month, 1).strftime('%b %Y').upper()
 

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -137,7 +137,8 @@ def new_event():
         db.session.commit()
         flash('Event added.', 'success')
         return redirect(url_for('admin.new_event'))
-    return render_template('admin/new_event.html', form=form)
+    events = Event.query.order_by(Event.start_date.desc()).all()
+    return render_template('admin/new_event.html', form=form, events=events)
 
 @admin_bp.route('/events/<int:event_id>/delete')
 def delete_event(event_id):


### PR DESCRIPTION
## Summary
- drop color field from event form
- show existing events on the admin event page
- expose events list to template as dictionaries to avoid JSON errors
- random color still generated in admin route

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6853eaea7d1483318f59542779367630