### PR TITLE
Improve calendar layout

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -669,6 +669,7 @@ a.btn:hover,
   width: 100%;
   border-collapse: collapse;
   margin-top: 20px;
+  table-layout: fixed;
 }
 .calendar th, .calendar td {
   border: 1px solid #ddd;
@@ -742,4 +743,6 @@ a.btn:hover,
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  width: 100%;
+  box-sizing: border-box;
 }

--- a/app/templates/calendar.html
+++ b/app/templates/calendar.html
@@ -153,6 +153,7 @@
             part.className = 'event-part';
             part.style.backgroundColor = ev.color;
             part.textContent = ev.title;
+            part.title = `${ev.title} (${ev.start_date} - ${ev.end_date})`;
             cell.appendChild(part);
           });
         }


### PR DESCRIPTION
## Summary
- add `table-layout: fixed` to keep calendar cells at fixed widths
- give calendar events full-width blocks
- add event details to event blocks' tooltips

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685904214f6083319eae0cde7a9dfa53