### PR TITLE
Add Teams link on detail page

### DIFF
--- a/app/templates/idea_detail.html
+++ b/app/templates/idea_detail.html
@@ -14,6 +14,12 @@
   <p><strong>Role Preference:</strong> {{ idea.intent }}</p>
   <p><strong>Votes:</strong> {{ idea.votes }}</p>
 
+  {% if not idea.is_anonymous and idea.submitter and idea.submitter != session.username %}
+    <p>
+      <a href="{{ generate_teams_link(idea.submitter) }}" target="_blank" class="connect-btn">💬 Chat on Teams</a>
+    </p>
+  {% endif %}
+
   {% if voted %}
     <p>You already voted for this idea.</p>
   {% else %}


### PR DESCRIPTION
## Summary
- allow connecting on Teams from an idea's detail view

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859083636208331a2e349276d3e2015