### PR TITLE
Fix vote count when deleting ideas

### DIFF
--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -142,6 +142,9 @@ def delete_idea(idea_id):
         flash("Access denied.", "error")
         return redirect(url_for('views.dashboard'))
 
+    # Remove votes tied to this idea so stats remain accurate
+    Vote.query.filter_by(idea_id=idea.id).delete()
+
     db.session.delete(idea)
     db.session.commit()
     flash("Idea deleted.", "success")


### PR DESCRIPTION
## Summary
- remove votes for an idea when it is deleted so stats stay accurate

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68596e2f1c28833193615adfca7e318c