### PR TITLE
Add upcoming events section

### DIFF
--- a/app/templates/calendar.html
+++ b/app/templates/calendar.html
@@ -27,13 +27,27 @@
   <ul>
     {% for ev in events %}
       <li>
-        <span style="background-color: {{ ev.color }}; padding: 2px 6px;">{{ ev.title }} ({{ ev.start_date }} - {{ ev.end_date }})</span>
+        <span style="background-color: {{ ev.color }}; padding: 2px 6px;">{{ ev.title }} ({{ ev.display_start }} - {{ ev.display_end }})</span>
         {% if session.role == 'admin' %}
           <a href="{{ url_for('admin.delete_event', event_id=ev.id) }}" onclick="return confirm('Delete this event?');">Delete</a>
         {% endif %}
       </li>
     {% else %}
       <li>No events</li>
+    {% endfor %}
+  </ul>
+
+  <h3>Upcoming Events</h3>
+  <ul>
+    {% for ev in upcoming_events %}
+      <li>
+        <span style="background-color: {{ ev.color }}; padding: 2px 6px;">{{ ev.title }} ({{ ev.display_start }} - {{ ev.display_end }})</span>
+        {% if session.role == 'admin' %}
+          <a href="{{ url_for('admin.delete_event', event_id=ev.id) }}" onclick="return confirm('Delete this event?');">Delete</a>
+        {% endif %}
+      </li>
+    {% else %}
+      <li>No upcoming events</li>
     {% endfor %}
   </ul>
 
@@ -153,7 +167,7 @@
             part.className = 'event-part';
             part.style.backgroundColor = ev.color;
             part.textContent = ev.title;
-            part.title = `${ev.title} (${ev.start_date} - ${ev.end_date})`;
+            part.title = `${ev.title} (${ev.display_start} - ${ev.display_end})`;
             cell.appendChild(part);
           });
         }

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -210,8 +210,29 @@ def events():
             'start_date': ev.start_date.isoformat(),
             'end_date': ev.end_date.isoformat(),
             'color': ev.color,
+            'display_start': ev.start_date.strftime('%d %b %Y').upper(),
+            'display_end': ev.end_date.strftime('%d %b %Y').upper(),
         }
         for ev in events_query
+    ]
+
+    upcoming_query = (
+        Event.query
+        .filter(Event.start_date > end_month)
+        .order_by(Event.start_date)
+        .all()
+    )
+    upcoming_events = [
+        {
+            'id': ev.id,
+            'title': ev.title,
+            'start_date': ev.start_date.isoformat(),
+            'end_date': ev.end_date.isoformat(),
+            'color': ev.color,
+            'display_start': ev.start_date.strftime('%d %b %Y').upper(),
+            'display_end': ev.end_date.strftime('%d %b %Y').upper(),
+        }
+        for ev in upcoming_query
     ]
 
     month_name = datetime(year, month, 1).strftime('%b %Y').upper()
@@ -222,4 +243,5 @@ def events():
         year=year,
         month_name=month_name,
         events=events,
+        upcoming_events=upcoming_events,
     )


### PR DESCRIPTION
## Summary
- query and format upcoming events
- show upcoming events after current month events
- use `DD MMM YYYY` formatting for event date displays

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685a1684b1488331a8fa82a6b2ca5ffb