### PR TITLE
Add admin configurable scrolling message

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -36,3 +36,10 @@ class EventForm(FlaskForm):
     start_date = DateField('Start Date', validators=[DataRequired()], format='%Y-%m-%d')
     end_date = DateField('End Date', validators=[DataRequired()], format='%Y-%m-%d')
     submit = SubmitField('Add Event')
+
+
+class DisplayMessageForm(FlaskForm):
+    text = StringField('Message Text', validators=[DataRequired(), Length(max=500)])
+    color = StringField('Text Color', validators=[Optional(), Length(max=20)], default='#FF0000')
+    blink = BooleanField('Blink Animation')
+    submit = SubmitField('Save Message')

--- a/app/models.py
+++ b/app/models.py
@@ -35,3 +35,13 @@ class Event(db.Model):
 
     def __repr__(self):
         return f"<Event {self.title} {self.start_date} - {self.end_date}>"
+
+
+class DisplayMessage(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    text = db.Column(db.String(500), nullable=False)
+    color = db.Column(db.String(20), default="#FF0000")
+    blink = db.Column(db.Boolean, default=False)
+
+    def __repr__(self):
+        return f"<DisplayMessage {self.text[:20]}>"

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -746,3 +746,31 @@ a.btn:hover,
   width: 100%;
   box-sizing: border-box;
 }
+
+/* Scrolling message above submit form */
+.scrolling-message {
+  overflow: hidden;
+  white-space: nowrap;
+  width: 100%;
+  box-sizing: border-box;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+.scrolling-message span {
+  display: inline-block;
+  padding-left: 100%;
+  animation: marquee 15s linear infinite;
+}
+
+.blink {
+  animation: blink 1s step-start infinite;
+}
+
+@keyframes marquee {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-100%); }
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
+}

--- a/app/templates/admin/admin_dashboard.html
+++ b/app/templates/admin/admin_dashboard.html
@@ -43,6 +43,7 @@
         <a href="{{ url_for('admin.export_all_data') }}" class="btn btn-secondary">📤 Export Raw DB</a>
         <a href="{{ url_for('admin.import_raw_data') }}" class="btn btn-secondary">📥 Import Raw DB</a>
         <a href="{{ url_for('admin.new_event') }}" class="btn btn-secondary">📅 Add Event</a>
+        <a href="{{ url_for('admin.manage_message') }}" class="btn btn-secondary">📢 Display Message</a>
     </div>
   </div>
 

--- a/app/templates/admin/manage_message.html
+++ b/app/templates/admin/manage_message.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+
+{% block title %}Display Message{% endblock %}
+
+{% block content %}
+  <h2>Configure Display Message</h2>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+      {{ form.text.label }}<br>
+      {{ form.text(class="input") }}
+    </div>
+    <div class="form-group">
+      {{ form.color.label }}<br>
+      {{ form.color(class="input", type="color") }}
+    </div>
+    <div class="form-group checkbox">
+      {{ form.blink() }} {{ form.blink.label }}
+    </div>
+    {{ form.submit(class="btn-primary") }}
+  </form>
+{% endblock %}

--- a/app/templates/submit.html
+++ b/app/templates/submit.html
@@ -3,6 +3,11 @@
 {% block title %}Submit Idea{% endblock %}
 
 {% block content %}
+  {% if display_message %}
+    <div class="scrolling-message{% if display_message.blink %} blink{% endif %}" style="color: {{ display_message.color }};">
+      <span>{{ display_message.text }}</span>
+    </div>
+  {% endif %}
   <div class="idea-form-wrapper animate-fade-in">
     <h2 class="form-title">📝 Submit a New Idea</h2>
 

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, flash,
 from sqlalchemy.exc import IntegrityError
 from datetime import datetime
 from app.forms import IdeaForm, VoteForm, LoginForm, EventForm
-from app.models import db, Idea, Vote, Event
+from app.models import db, Idea, Vote, Event, DisplayMessage
 from app.utils import (
     generate_tags,
     export_ideas_to_excel,
@@ -34,6 +34,7 @@ def submit_idea():
         return redirect(url_for('auth.login'))
 
     form = IdeaForm()
+    display_message = DisplayMessage.query.first()
     if form.validate_on_submit():
         title = form.title.data
         description = form.description.data
@@ -67,7 +68,7 @@ def submit_idea():
             patent_url=patent_url
         )
 
-    return render_template('submit.html', form=form)
+    return render_template('submit.html', form=form, display_message=display_message)
 
 @views_bp.route('/dashboard')
 def dashboard():

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -1,9 +1,9 @@
 # File: app/views/admin.py
 
 from flask import Blueprint, render_template, session, redirect, url_for, flash, request, send_file
-from app.models import db, Idea, Event, Vote
+from app.models import db, Idea, Event, Vote, DisplayMessage
 from app.auth import is_admin
-from app.forms import EventForm
+from app.forms import EventForm, DisplayMessageForm
 import random
 import os, json
 from datetime import datetime
@@ -149,6 +149,29 @@ def new_event():
         return redirect(url_for('admin.new_event'))
     events = Event.query.order_by(Event.start_date.desc()).all()
     return render_template('admin/new_event.html', form=form, events=events)
+
+
+@admin_bp.route('/message', methods=['GET', 'POST'])
+def manage_message():
+    form = DisplayMessageForm()
+    message = DisplayMessage.query.first()
+    if form.validate_on_submit():
+        if not message:
+            message = DisplayMessage()
+        message.text = form.text.data
+        message.color = form.color.data or '#FF0000'
+        message.blink = form.blink.data
+        db.session.add(message)
+        db.session.commit()
+        flash('Display message updated.', 'success')
+        return redirect(url_for('admin.manage_message'))
+
+    if message:
+        form.text.data = message.text
+        form.color.data = message.color
+        form.blink.data = message.blink
+
+    return render_template('admin/manage_message.html', form=form)
 
 @admin_bp.route('/events/<int:event_id>/delete')
 def delete_event(event_id):


### PR DESCRIPTION
## Summary
- store display banner text in a new `DisplayMessage` model
- allow admins to configure the banner message
- show the configuration link in the admin dashboard
- render banner above idea submission form
- style scrolling/blinking banner

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a17d4f1948331b9d8314f4ee815af