### PR TITLE
Fix display message styles

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -751,7 +751,9 @@ a.btn:hover,
 .scrolling-message,
 .static-message {
   font-weight: bold;
-  margin-bottom: 10px;
+  margin: 0 auto 10px;
+  max-width: 600px;
+  text-align: center;
 }
 
 .scrolling-message {
@@ -776,7 +778,7 @@ a.btn:hover,
 
 @keyframes marquee {
   0% { transform: translateX(0); }
-  100% { transform: translateX(-50%); }
+  100% { transform: translateX(-100%); }
 }
 
 @keyframes blink {


### PR DESCRIPTION
## Summary
- center static display message above the idea form
- keep scrolling display continuously moving

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a9b3c68c48331b7ec5c99b599b06c