### PR TITLE
Add display message link and hover pause

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -41,6 +41,7 @@ class EventForm(FlaskForm):
 class DisplayMessageForm(FlaskForm):
     text = StringField('Message Text', validators=[DataRequired(), Length(max=500)])
     color = StringField('Text Color', validators=[Optional(), Length(max=20)], default='#FF0000')
+    link = StringField('Link', validators=[Optional(), Length(max=500)])
     blink = BooleanField('Blink Animation')
     enabled = BooleanField('Enable Message', default=True)
     scroll = BooleanField('Scrolling Animation', default=True)

--- a/app/models.py
+++ b/app/models.py
@@ -41,6 +41,7 @@ class DisplayMessage(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     text = db.Column(db.String(500), nullable=False)
     color = db.Column(db.String(20), default="#FF0000")
+    link = db.Column(db.String(500))
     blink = db.Column(db.Boolean, default=False)
     enabled = db.Column(db.Boolean, default=True)
     scroll = db.Column(db.Boolean, default=True)

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -767,6 +767,14 @@ a.btn:hover,
   padding-left: 100%;
   animation: marquee 15s linear infinite;
 }
+.scrolling-message:hover span {
+  animation-play-state: paused;
+}
+
+.message-link {
+  color: inherit;
+  text-decoration: none;
+}
 
 .scrolling-message span::after {
   content: attr(data-text) '\2003';

--- a/app/templates/admin/manage_message.html
+++ b/app/templates/admin/manage_message.html
@@ -14,6 +14,10 @@
       {{ form.color.label }}<br>
       {{ form.color(class="input", type="color") }}
     </div>
+    <div class="form-group">
+      {{ form.link.label }}<br>
+      {{ form.link(class="input", placeholder="Optional link") }}
+    </div>
     <div class="form-group checkbox">
       {{ form.blink() }} {{ form.blink.label }}
     </div>

--- a/app/templates/submit.html
+++ b/app/templates/submit.html
@@ -6,11 +6,21 @@
   {% if display_message and display_message.enabled %}
     {% if display_message.scroll %}
       <div class="scrolling-message{% if display_message.blink %} blink{% endif %}" style="color: {{ display_message.color }};">
-        <span data-text="{{ display_message.text }}">{{ display_message.text }}&emsp;</span>
+        <span data-text="{{ display_message.text }}">
+          {% if display_message.link %}
+            <a href="{{ display_message.link }}" class="message-link" target="_blank">{{ display_message.text }}</a>&emsp;
+          {% else %}
+            {{ display_message.text }}&emsp;
+          {% endif %}
+        </span>
       </div>
     {% else %}
       <div class="static-message{% if display_message.blink %} blink{% endif %}" style="color: {{ display_message.color }};">
-        {{ display_message.text }}
+        {% if display_message.link %}
+          <a href="{{ display_message.link }}" class="message-link" target="_blank">{{ display_message.text }}</a>
+        {% else %}
+          {{ display_message.text }}
+        {% endif %}
       </div>
     {% endif %}
   {% endif %}

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -160,6 +160,7 @@ def manage_message():
             message = DisplayMessage()
         message.text = form.text.data
         message.color = form.color.data or '#FF0000'
+        message.link = form.link.data or None
         message.blink = form.blink.data
         message.enabled = form.enabled.data
         message.scroll = form.scroll.data
@@ -171,6 +172,7 @@ def manage_message():
     if message:
         form.text.data = message.text
         form.color.data = message.color
+        form.link.data = message.link
         form.blink.data = message.blink
         form.enabled.data = message.enabled
         form.scroll.data = message.scroll


### PR DESCRIPTION
## Summary
- allow linking in admin-managed display messages
- show the link in submit page when provided
- pause scrolling display message on hover and style link

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ae39c6af08331bddd07e15b950201