### PR TITLE
Fix marquee repetition and link handling

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -774,10 +774,11 @@ a.btn:hover,
 .message-link {
   color: inherit;
   text-decoration: none;
+  display: block;
 }
 
 .scrolling-message span::after {
-  content: attr(data-text) '\2003';
+  content: attr(data-text) '\2003' attr(data-text) '\2003' attr(data-text) '\2003' attr(data-text) '\2003';
 }
 
 .blink {

--- a/app/templates/submit.html
+++ b/app/templates/submit.html
@@ -5,23 +5,17 @@
 {% block content %}
   {% if display_message and display_message.enabled %}
     {% if display_message.scroll %}
-      <div class="scrolling-message{% if display_message.blink %} blink{% endif %}" style="color: {{ display_message.color }};">
-        <span data-text="{{ display_message.text }}">
-          {% if display_message.link %}
-            <a href="{{ display_message.link }}" class="message-link" target="_blank">{{ display_message.text }}</a>&emsp;
-          {% else %}
-            {{ display_message.text }}&emsp;
-          {% endif %}
-        </span>
-      </div>
+      {% if display_message.link %}<a href="{{ display_message.link }}" class="message-link" target="_blank">{% endif %}
+        <div class="scrolling-message{% if display_message.blink %} blink{% endif %}" style="color: {{ display_message.color }};">
+          <span data-text="{{ display_message.text }}">{{ display_message.text }}</span>
+        </div>
+      {% if display_message.link %}</a>{% endif %}
     {% else %}
-      <div class="static-message{% if display_message.blink %} blink{% endif %}" style="color: {{ display_message.color }};">
-        {% if display_message.link %}
-          <a href="{{ display_message.link }}" class="message-link" target="_blank">{{ display_message.text }}</a>
-        {% else %}
+      {% if display_message.link %}<a href="{{ display_message.link }}" class="message-link" target="_blank">{% endif %}
+        <div class="static-message{% if display_message.blink %} blink{% endif %}" style="color: {{ display_message.color }};">
           {{ display_message.text }}
-        {% endif %}
-      </div>
+        </div>
+      {% if display_message.link %}</a>{% endif %}
     {% endif %}
   {% endif %}
   <div class="idea-form-wrapper animate-fade-in">

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -160,7 +160,10 @@ def manage_message():
             message = DisplayMessage()
         message.text = form.text.data
         message.color = form.color.data or '#FF0000'
-        message.link = form.link.data or None
+        link_input = form.link.data.strip() if form.link.data else None
+        if link_input and not link_input.startswith(('http://', 'https://')):
+            link_input = 'https://' + link_input
+        message.link = link_input
         message.blink = form.blink.data
         message.enabled = form.enabled.data
         message.scroll = form.scroll.data


### PR DESCRIPTION
## Summary
- repeat scrolling banner text continuously
- make the entire banner clickable when a link is provided
- preserve protocol for message links

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685aecd15dd883318a974eb1d9bd3894