### PR TITLE
Add admin database export/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ Verify Python files compile without syntax errors:
 ```bash
 python -m py_compile $(git ls-files '*.py')
 ```
+
+## Admin Data Export/Import
+
+Administrators can export and import idea data in two formats from the dashboard:
+
+1. **Raw DB (JSON)** – exports only the ideas in JSON form. Existing `Export Raw DB` and `Import Raw DB` actions handle this format.
+2. **Full Database** – downloads or uploads the entire SQLite database including user accounts, votes, and calendar events.
+
+Use these features to migrate or back up all application data.

--- a/app/templates/admin/admin_dashboard.html
+++ b/app/templates/admin/admin_dashboard.html
@@ -40,8 +40,10 @@
     </table>
 
     <div class="admin-actions">
-        <a href="{{ url_for('admin.export_all_data') }}" class="btn btn-secondary">📤 Export Raw DB</a>
-        <a href="{{ url_for('admin.import_raw_data') }}" class="btn btn-secondary">📥 Import Raw DB</a>
+        <a href="{{ url_for('admin.export_all_data') }}" class="btn btn-secondary">📤 Export Raw DB (JSON)</a>
+        <a href="{{ url_for('admin.import_raw_data') }}" class="btn btn-secondary">📥 Import Raw DB (JSON)</a>
+        <a href="{{ url_for('admin.export_database') }}" class="btn btn-secondary">📤 Export Full DB</a>
+        <a href="{{ url_for('admin.import_database') }}" class="btn btn-secondary">📥 Import Full DB</a>
         <a href="{{ url_for('admin.new_event') }}" class="btn btn-secondary">📅 Add Event</a>
         <a href="{{ url_for('admin.manage_message') }}" class="btn btn-secondary">📢 Display Message</a>
     </div>

--- a/app/templates/admin/import_db.html
+++ b/app/templates/admin/import_db.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+{% block title %}Import Database – Admin{% endblock %}
+
+{% block content %}
+  <h2 class="page-heading">📥 Import Full Database</h2>
+
+  <form method="POST" enctype="multipart/form-data" class="import-form">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="form-group">
+      <label for="file">Choose SQLite database file:</label>
+      <input type="file" name="file" accept=".db" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Import</button>
+  </form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- enable administrators to download or upload the full SQLite DB
- keep existing JSON import/export and document both formats
- clarify admin dashboard with buttons for raw JSON and full DB actions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685b81ed1e6483319ee138a341aa3cec