### PR TITLE
Fix database path for admin import/export

### DIFF
--- a/app/backup.py
+++ b/app/backup.py
@@ -5,12 +5,12 @@ from apscheduler.schedulers.background import BackgroundScheduler
 import atexit
 
 # Paths
-# Use the same location as SQLALCHEMY_DATABASE_URI which points to
-# a SQLite file relative to the application package directory.
-# This ensures the backup job looks for the correct database file.
-BASE_DIR = os.path.dirname(__file__)
-DB_PATH = os.path.join(BASE_DIR, 'innovation.db')
-BACKUP_DIR = os.path.join(os.path.abspath(os.path.join(BASE_DIR, '..')), 'db_backups')
+# Use the same location as SQLALCHEMY_DATABASE_URI which points to the
+# database file stored inside the instance folder.  Using the instance
+# directory keeps the database separate from the application code.
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+DB_PATH = os.path.join(BASE_DIR, 'instance', 'innovation.db')
+BACKUP_DIR = os.path.join(BASE_DIR, 'db_backups')
 
 scheduler = BackgroundScheduler()
 

--- a/app/views/admin.py
+++ b/app/views/admin.py
@@ -127,7 +127,8 @@ def export_all_data():
 def export_database():
     """Download the raw SQLite database file."""
     db.session.commit()  # ensure latest data written
-    return send_file(DB_PATH, as_attachment=True, download_name='innovation.db')
+    db_file = DB_PATH  # database located in instance folder
+    return send_file(db_file, as_attachment=True, download_name='innovation.db')
 
 
 @admin_bp.route('/refresh-votes', methods=['POST'])
@@ -270,9 +271,10 @@ def import_database():
 
         try:
             backup_path = DB_PATH + '.bak'
-            if os.path.exists(DB_PATH):
-                shutil.copy2(DB_PATH, backup_path)
-            file.save(DB_PATH)
+            db_file = DB_PATH  # database located in instance folder
+            if os.path.exists(db_file):
+                shutil.copy2(db_file, backup_path)
+            file.save(db_file)
             db.engine.dispose()
             flash('Database imported successfully.', 'success')
         except Exception as e:


### PR DESCRIPTION
## Summary
- store DB in `instance/innovation.db`
- use updated path during admin DB export/import

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- manual test: create idea, copy DB, remove DB, restore DB and verify idea count

------
https://chatgpt.com/codex/tasks/task_e_685df5e37b408331ac6a3c6668ebb2d9