### PR TITLE
Display team members on idea detail page

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -323,6 +323,12 @@ body {
   color: #FFCD00;
 }
 
+.team-members {
+  list-style: disc;
+  margin-left: 20px;
+  margin-bottom: 15px;
+}
+
 @keyframes fadeSlideIn {
   from {
     opacity: 0;

--- a/app/templates/idea_detail.html
+++ b/app/templates/idea_detail.html
@@ -11,6 +11,16 @@
   <p><strong>Tags:</strong> {{ idea.tags }}</p>
   <p><strong>Submitted:</strong> {{ idea.timestamp.strftime('%Y-%m-%d %H:%M') }}</p>
   <p><strong>Submitted By:</strong> {{ 'Anonymous' if idea.is_anonymous else idea.submitter }}</p>
+  {% if idea.teammates %}
+    <div class="section">
+      <h3>👥 Team Members</h3>
+      <ul class="team-members">
+        {% for member in idea.teammates.split(',') %}
+          <li>{{ member.strip() }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
   <p><strong>Role Preference:</strong> {{ idea.intent }}</p>
   <p><strong>Votes:</strong> {{ idea.votes }}</p>
 


### PR DESCRIPTION
## Summary
- add missing display of team members in idea detail page
- style team member list in CSS

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68628063d3888331a3348356b37b4fef