### PR TITLE
Add admin idea groups slide stacks

### DIFF
--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -799,3 +799,55 @@ a.btn:hover,
 @keyframes blink {
   50% { opacity: 0; }
 }
+
+/* Idea grouping stacks */
+.group-section {
+  margin-top: 40px;
+}
+
+.groups {
+  list-style: none;
+  padding: 0;
+}
+
+.idea-group {
+  margin-bottom: 30px;
+}
+
+.idea-stack {
+  list-style: none;
+  position: relative;
+  height: 160px;
+  padding: 20px 0;
+  cursor: pointer;
+}
+
+.idea-stack .idea-card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  padding: 15px;
+  width: 250px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transition: transform 0.4s cubic-bezier(.63,.15,.03,1.12);
+}
+
+.idea-stack .idea-card:nth-child(1) { z-index: 5; transform: rotate(-2deg); }
+.idea-stack .idea-card:nth-child(2) { z-index: 4; transform: rotate(-7deg); }
+.idea-stack .idea-card:nth-child(3) { z-index: 3; transform: rotate(5deg); }
+.idea-stack .idea-card:nth-child(4) { z-index: 2; transform: rotate(-12deg); }
+.idea-stack .idea-card:nth-child(5) { z-index: 1; transform: rotate(8deg); }
+
+.idea-stack.open .idea-card { transform: none; }
+
+.idea-stack .small-desc {
+  font-size: 0.85em;
+  margin: 4px 0;
+}
+
+.idea-stack .meta {
+  font-size: 0.75em;
+  color: #555;
+}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -70,6 +70,28 @@
     <form method="GET" action="{{ url_for('views.export_ideas') }}" class="export-form">
       <button type="submit" class="export-btn">📤 Export All Ideas to Excel</button>
     </form>
+
+    {% if session.role == 'admin' and groups %}
+      <div class="group-section">
+        <h3 class="group-title">📂 Idea Groups</h3>
+        <ul class="groups">
+          {% for tag, items in groups.items() %}
+            <li class="idea-group">
+              <h4>{{ tag }}</h4>
+              <ul class="idea-stack">
+                {% for item in items %}
+                  <li class="idea-card" style="--i: {{ loop.index0 }};">
+                    <h5>{{ item.title }}</h5>
+                    <p class="small-desc">{{ item.description[:80] }}{% if item.description|length > 80 %}...{% endif %}</p>
+                    <p class="meta">By {{ 'Anonymous' if item.is_anonymous else item.submitter }}</p>
+                  </li>
+                {% endfor %}
+              </ul>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
   {% else %}
     <p>No ideas submitted yet.</p>
   {% endif %}
@@ -159,5 +181,19 @@
     function escapeReg(str) {
       return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
+
+    document.querySelectorAll('.idea-stack').forEach(stack => {
+      stack.addEventListener('click', () => {
+        const open = stack.classList.toggle('open');
+        const cards = stack.querySelectorAll('.idea-card');
+        cards.forEach((card, idx) => {
+          if (open) {
+            card.style.transform = `translateX(${idx * 260}px)`;
+          } else {
+            card.style.transform = '';
+          }
+        });
+      });
+    });
   </script>
 {% endblock %}

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -89,6 +89,13 @@ def dashboard():
     voted_ideas = {v.idea_id for v in voted}
     vote_form = VoteForm()
 
+    groups = None
+    if session.get('role') == 'admin':
+        groups = {}
+        for idea in ideas:
+            tag = idea.tags.split(',')[0].strip() if idea.tags else 'Untagged'
+            groups.setdefault(tag, []).append(idea)
+
     return render_template(
         'dashboard.html',
         ideas=ideas,
@@ -96,6 +103,7 @@ def dashboard():
         voted_ideas=voted_ideas,
         vote_form=vote_form,
         filter_my=filter_my,
+        groups=groups,
     )
 
 @views_bp.route('/idea/<int:idea_id>')


### PR DESCRIPTION
## Summary
- group dashboard ideas by first tag for admins
- add idea stack section with slide animation
- style and JS for sliding stacked cards
- limit idea grouping logic to admins only

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686f9c4d769c83318418e6da751a6369